### PR TITLE
Fix for MD2, MD4 and MD5 Are Weak Hash Functions

### DIFF
--- a/src/main/java/org/cysecurity/cspf/jvl/model/HashMe.java
+++ b/src/main/java/org/cysecurity/cspf/jvl/model/HashMe.java
@@ -13,7 +13,7 @@ public class HashMe {
          StringBuffer sb=null;
         try
         {
-            MessageDigest md = MessageDigest.getInstance("MD5");
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
             md.update(str.getBytes());
             byte byteData[] = md.digest();
             sb= new StringBuffer();


### PR DESCRIPTION
[Issue Link](https://reshift.reshiftsecurity.com/issues/eyJ0YWdfaWQiOiB7InJlcG9zaXRvcnlfaWQiOiB7InByb3ZpZGVyX2lkIjogIkdpdGh1YiIsICJwcm92aWRlcl9vd25lcl9pZCI6ICI0ODEwMzYxOSIsICJwcm92aWRlcl9yZXBvc2l0b3J5X2lkIjogIk1ERXdPbEpsY0c5emFYUnZjbmt5TmpNNU5EZ3lNRGc9In0sICJuYW1lIjogIm9yaWdpbi9tYXN0ZXIifSwgInJlcG9ydF9pZCI6IDc0OTl9?issue_id=eyJyZXBvcnRfaWQiOiB7InRhZ19pZCI6IHsicmVwb3NpdG9yeV9pZCI6IHsicHJvdmlkZXJfaWQiOiAiR2l0aHViIiwgInByb3ZpZGVyX293bmVyX2lkIjogIjQ4MTAzNjE5IiwgInByb3ZpZGVyX3JlcG9zaXRvcnlfaWQiOiAiTURFd09sSmxjRzl6YVhSdmNua3lOak01TkRneU1EZz0ifSwgIm5hbWUiOiAib3JpZ2luL21hc3RlciJ9LCAicmVwb3J0X2lkIjogNzQ5OX0sICJpc3N1ZV9pZCI6IDE5MDYxMjJ9)

A weakness in the MD5 cryptographic hash function can result in a high number of different messages with the same MD5 hash (known as a "collision").  Previous work on MD5 collisions between 2004 and 2007 showed that the use of this hash function can lead to theoretical attack scenarios; however, more recent work has proven that this scenario can be exploited in practice.  This exposes any system which relies on the MD5 hashing mechanism to a realistic threat of attack.   It should be noted that the SHA-1 algorithm has also been found to exhibit a lack of collision resistance.


MD2, MD4, MD5 are not recommended and a replacement such as SHA-2 (-224, -256, -384, -512) should be considered

Here is a bad example using unsafe MD5:

```java
MessageDigest aBadDigest = MessageDigest.getInstance("MD5");
```

Which should be replaced with at least a SHA-2 algorithm:

```java
MessageDigest aBetterDigest = MessageDigest.getInstance("SHA-256");
```
